### PR TITLE
[Style] 01/23 hanjeonghyun 주요 색상들 전역 스타일 추가 #14

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,20 @@
-*, *::before, *::after {
+:root {
+  --mainRed: #e50914;
+  --subRed: #a80c18;
+  --darkRed: #600000;
+  --black: #000000;
+}
+
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
-ul, ol {
+ul,
+ol {
   list-style: none;
 }
 body,
@@ -26,8 +36,8 @@ body {
   min-height: 100vh;
   text-rendering: optimizeSpeed;
   line-height: 1.5;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 img,
 picture {


### PR DESCRIPTION
global.css에 메인이 되는 네 가지 색상 컬러 팔레트를 추가

앞으로 사용 시에는 var(--mainRed)와 같은 형식으로 사용하시면 됩니다!

추가된 색상은 아래와 같습니다!

:root {
  --mainRed: #e50914;
  --subRed: #a80c18;
  --darkRed: #600000;
  --black: #000000;
}

ex) background-color : var(--mainRed)

